### PR TITLE
Tweaks from archlinux arm

### DIFF
--- a/amlogic.service
+++ b/amlogic.service
@@ -1,0 +1,14 @@
+[Unit]
+Description="ODROID-C2 Amlogic Display Configuration"
+
+DefaultDependencies=no
+Requires=sysinit.target
+After=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/c2_init.sh
+
+[Install]
+WantedBy=basic.target
+WantedBy=sysinit.target

--- a/c2_init.sh
+++ b/c2_init.sh
@@ -17,13 +17,14 @@ common_display_setup() {
         M="0 0 $(($X - 1)) $(($Y - 1))"
         Y_VIRT=$(($Y * 2))
         fbset -fb /dev/fb0 -g $X $Y $X $Y_VIRT $bpp
-        fbset -fb /dev/fb1 -g 32 32 32 32 32
         echo $mode > /sys/class/display/mode
         echo 0 > /sys/class/graphics/fb0/free_scale
         echo 1 > /sys/class/graphics/fb0/freescale_mode
         echo $M > /sys/class/graphics/fb0/free_scale_axis
         echo $M > /sys/class/graphics/fb0/window_axis
+
         echo 0 > /sys/class/graphics/fb1/free_scale
+        echo 1 > /sys/class/graphics/fb1/freescale_mode
         if [ "$bpp" = "32" ]; then
             echo d01068b4 0x7fc0 > /sys/kernel/debug/aml_reg/paddr
         fi

--- a/c2_init.sh
+++ b/c2_init.sh
@@ -14,9 +14,9 @@ DISP_MODE=/sys/class/display/mode
 echo $mode > $DISP_MODE
 
 common_display_setup() {
-		M="0 0 $(($X - 1)) $(($Y - 1))"
-		Y_VIRT=$(($Y * 2))
-		fbset -fb /dev/fb0 -g $X $Y $X $Y_VIRT $bpp
+        M="0 0 $(($X - 1)) $(($Y - 1))"
+        Y_VIRT=$(($Y * 2))
+        fbset -fb /dev/fb0 -g $X $Y $X $Y_VIRT $bpp
         fbset -fb /dev/fb1 -g 32 32 32 32 32
         echo $mode > /sys/class/display/mode
         echo 0 > /sys/class/graphics/fb0/free_scale
@@ -24,6 +24,9 @@ common_display_setup() {
         echo $M > /sys/class/graphics/fb0/free_scale_axis
         echo $M > /sys/class/graphics/fb0/window_axis
         echo 0 > /sys/class/graphics/fb1/free_scale
+        if [ "$bpp" = "32" ]; then
+            echo d01068b4 0x7fc0 > /sys/kernel/debug/aml_reg/paddr
+        fi
 }
 
 case $mode in


### PR DESCRIPTION
A few tweaks from Arch Linux ARM
- include the aml_fix_display logic into c2_init.sh's common_display_setup
- alter the calls to setup fb1 so that it doesn't overlay on fb0 during X use
- add a systemd service that runs after sysinit.target, very early in the post-initrd boot.
