### PR TITLE
add check for headless mode

### DIFF
--- a/c2_init.sh
+++ b/c2_init.sh
@@ -11,6 +11,9 @@ HPD_STATE=/sys/class/amhdmitx/amhdmitx0/hpd_state
 DISP_CAP=/sys/class/amhdmitx/amhdmitx0/disp_cap
 DISP_MODE=/sys/class/display/mode
 
+# if setenv nographics "1" in boot.ini then this needs to fail
+[[ -f $DISP_MODE ]] || exit 0
+
 echo $mode > $DISP_MODE
 
 common_display_setup() {


### PR DESCRIPTION
If the user has `setenv nographics "1"` in `/boot/boot.ini` then this script generates tons of errors and leave the service in a fail state.  This line allows a check for it and clean exit.
